### PR TITLE
Add ratelimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ around the official Stripe API documentation [website](https://stripe.com/docs/a
 The Stripe Terraform Provider documentation can be found on the Terraform Provider documentation [website](https://registry.terraform.io/providers/umisora/stripe/latest).
 
 ## Usage:
+
 ```terraform
 terraform {
   required_providers {
@@ -23,3 +24,53 @@ provider "stripe" {
 ### Environmental variable support
 
 The parameter `api_key` can be omitted when the `STRIPE_API_KEY` environmental variable is present.
+
+### Local Debug
+
+- With Terraform Cloud
+
+If you want to test new code with code already running on Terraform Cloud:
+
+- Build the provider with `go build main.go`
+- Move the final binary to the `mv main ~/.terraform.d/plugins/local/umisora/stripe/100/darwin_amd64/terraform-provider-stripe_v100`
+- Actually run the code using the Provider code locally. Change the backend from remote to local.
+
+```
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+  # backend "remote" {
+  #   hostname     = "app.terraform.io"
+  #   organization = "xxx"
+
+  #   workspaces {
+  #     prefix = "xxxx-"
+  #   }
+  # }
+}
+```
+
+- Run `terraform init -migrate-state.` Answer "Yes" when prompted to copy (migrate) tfstate from remote to local.
+- Point the provider to local.
+
+```
+terraform {
+  # Providers
+  required_providers {
+    stripe = {
+      //source = "umisora/stripe"
+      source  = "terraform.local/umisora/stripe"
+      version = "~> 1.3.1"
+    }
+  }
+  # Terrafirn Versuib
+  required_version = "~> 1.0.0"
+}
+```
+
+- Run `terraform plan`
+
+If you are using TFENV and encounter an error during Init due to Apple Silicon, reinstall Terraform.
+tfenv uninstall 1.0.10
+TFENV_ARCH=amd64 tfenv install 1.0.10

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.8.4 // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
+	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/stripe/resource_stripe_coupon.go
+++ b/stripe/resource_stripe_coupon.go
@@ -162,8 +162,12 @@ func resourceStripeCouponCreate(ctx context.Context, d *schema.ResourceData, m i
 			params.AddMetadata(k, ToString(v))
 		}
 	}
-
-	coupon, err := c.Coupons.New(params)
+	var coupon *stripe.Coupon
+	err := withRateLimiting(func() error {
+		var errLocal error
+		coupon, errLocal = c.Coupons.New(params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -182,7 +186,12 @@ func resourceStripeCouponRead(_ context.Context, d *schema.ResourceData, m inter
 	params := &stripe.CouponParams{}
 	params.AddExpand("applies_to")
 
-	coupon, err := c.Coupons.Get(d.Id(), params)
+	var coupon *stripe.Coupon
+	err := withRateLimiting(func() error {
+		var errLocal error
+		coupon, errLocal = c.Coupons.Get(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,7 +237,10 @@ func resourceStripeCouponUpdate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
-	_, err := c.Coupons.Update(d.Id(), params)
+	err := withRateLimiting(func() error {
+		_, errLocal := c.Coupons.Update(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -239,7 +251,10 @@ func resourceStripeCouponUpdate(ctx context.Context, d *schema.ResourceData, m i
 func resourceStripeCouponDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
 
-	_, err := c.Coupons.Del(d.Id(), nil)
+	err := withRateLimiting(func() error {
+		_, errLocal := c.Coupons.Del(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/stripe/resource_stripe_customer.go
+++ b/stripe/resource_stripe_customer.go
@@ -124,7 +124,12 @@ func resourceStripeCustomer() *schema.Resource {
 func resourceStripeCustomerRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
 
-	customer, err := c.Customers.Get(d.Id(), nil)
+	var customer *stripe.Customer
+	err := withRateLimiting(func() error {
+		var errLocal error
+		customer, errLocal = c.Customers.Get(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -320,7 +325,12 @@ func resourceStripeCustomerCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	customer, err := c.Customers.New(params)
+	var customer *stripe.Customer
+	err := withRateLimiting(func() error {
+		var errLocal error
+		customer, errLocal = c.Customers.New(params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -432,7 +442,11 @@ func resourceStripeCustomerUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	_, err := c.Customers.Update(d.Id(), params)
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.Customers.Update(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -444,7 +458,11 @@ func resourceStripeCustomerUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceStripeCustomerDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
 
-	_, err := c.Customers.Del(d.Id(), nil)
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.Customers.Del(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -227,7 +227,12 @@ func resourceStripePrice() *schema.Resource {
 
 func resourceStripePriceRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
-	price, err := c.Prices.Get(d.Id(), nil)
+	var price *stripe.Price
+	err := withRateLimiting(func() error {
+		var errLocal error
+		price, errLocal = c.Prices.Get(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -405,7 +410,12 @@ func resourceStripePriceCreate(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 
-	price, err := c.Prices.New(params)
+	var price *stripe.Price
+	err := withRateLimiting(func() error {
+		var errLocal error
+		price, errLocal = c.Prices.New(params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -451,7 +461,10 @@ func resourceStripePriceUpdate(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 
-	_, err := c.Prices.Update(d.Id(), params)
+	err := withRateLimiting(func() error {
+		_, errLocal := c.Prices.Update(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/stripe/resource_stripe_product.go
+++ b/stripe/resource_stripe_product.go
@@ -94,7 +94,13 @@ func resourceStripeProduct() *schema.Resource {
 
 func resourceStripeProductRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
-	product, err := c.Products.Get(d.Id(), nil)
+
+	var product *stripe.Product
+	err := withRateLimiting(func() error {
+		var errLocal error
+		product, errLocal = c.Products.Get(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -171,7 +177,12 @@ func resourceStripeProductCreate(ctx context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	product, err := c.Products.New(params)
+	var product *stripe.Product
+	err := withRateLimiting(func() error {
+		var errLocal error
+		product, errLocal = c.Products.New(params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -236,7 +247,11 @@ func resourceStripeProductUpdate(ctx context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	_, err := c.Products.Update(d.Id(), params)
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.Products.Update(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -246,7 +261,12 @@ func resourceStripeProductUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceStripeProductDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
-	_, err := c.Products.Del(d.Id(), nil)
+
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.Products.Del(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/stripe/resource_stripe_promotion_code.go
+++ b/stripe/resource_stripe_promotion_code.go
@@ -146,8 +146,12 @@ func resourceStripePromotionCodeCreate(ctx context.Context, d *schema.ResourceDa
 			params.AddMetadata(k, ToString(v))
 		}
 	}
-
-	promotionCode, err := c.PromotionCodes.New(params)
+	var promotionCode *stripe.PromotionCode
+	err := withRateLimiting(func() error {
+		var errLocal error
+		promotionCode, errLocal = c.PromotionCodes.New(params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -158,7 +162,13 @@ func resourceStripePromotionCodeCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceStripePromotionCodeRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
-	promotionCode, err := c.PromotionCodes.Get(d.Id(), nil)
+
+	var promotionCode *stripe.PromotionCode
+	err := withRateLimiting(func() error {
+		var errLocal error
+		promotionCode, errLocal = c.PromotionCodes.Get(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -209,7 +219,12 @@ func resourceStripePromotionCodeUpdate(ctx context.Context, d *schema.ResourceDa
 			params.AddMetadata(k, ToString(v))
 		}
 	}
-	_, err := c.PromotionCodes.Update(d.Id(), params)
+
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.PromotionCodes.Update(d.Id(), params)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/stripe/resource_stripe_webhook_endpoint.go
+++ b/stripe/resource_stripe_webhook_endpoint.go
@@ -64,7 +64,12 @@ func resourceStripeWebhookEndpoint() *schema.Resource {
 func resourceStripeWebhookEndpointRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
 
-	webhookEndpoint, err := c.WebhookEndpoints.Get(d.Id(), nil)
+	var webhookEndpoint *stripe.WebhookEndpoint
+	err := withRateLimiting(func() error {
+		var errLocal error
+		webhookEndpoint, errLocal = c.WebhookEndpoints.Get(d.Id(), nil)
+		return errLocal
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -93,7 +98,13 @@ func resourceStripeWebhookEndpointCreate(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	webhookEndpoint, err := c.WebhookEndpoints.New(params)
+	var webhookEndpoint *stripe.WebhookEndpoint
+	err := withRateLimiting(func() error {
+		var errLocal error
+		webhookEndpoint, errLocal = c.WebhookEndpoints.New(params)
+		return errLocal
+	})
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -133,7 +144,12 @@ func resourceStripeWebhookEndpointUpdate(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	_, err := c.WebhookEndpoints.Update(d.Id(), params)
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.WebhookEndpoints.Update(d.Id(), params)
+		return errLocal
+	})
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -144,7 +160,12 @@ func resourceStripeWebhookEndpointUpdate(ctx context.Context, d *schema.Resource
 func resourceStripeWebhookEndpointDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.API)
 
-	_, err := c.WebhookEndpoints.Del(d.Id(), nil)
+	err := withRateLimiting(func() error {
+		var errLocal error
+		_, errLocal = c.WebhookEndpoints.Del(d.Id(), nil)
+		return errLocal
+	})
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Stripe has particularly strict API Rate Limit during TestMode. When resources increase, executing the Plan also becomes impossible. In order to resolve these issues, the Provider has set a conservative Rate Limit. There are restrictions on the number of parallel executions.

If stability is not achieved even with this configuration, it may be necessary to add wait times of 0.5 seconds, etc.